### PR TITLE
Add default dashboard for OpenStack monitoring (#342)

### DIFF
--- a/grafana-init/build.yml
+++ b/grafana-init/build.yml
@@ -3,4 +3,3 @@ variants:
   - tag: 2.0.0
     aliases:
       - :pike-{date}-{time}
- 

--- a/grafana-init/dashboards.d/08-openstack.json
+++ b/grafana-init/dashboards.d/08-openstack.json
@@ -372,7 +372,6 @@
           "editable": true,
           "type": "graph",
           "loadingEditor": false,
-          
           "renderer": "flot",
           "x-axis": true,
           "y-axis": true,
@@ -492,7 +491,6 @@
           "editable": true,
           "type": "graph",
           "id": 13,
-          
           "renderer": "flot",
           "x-axis": true,
           "y-axis": true,
@@ -615,7 +613,6 @@
           "editable": true,
           "type": "graph",
           "id": 14,
-          
           "renderer": "flot",
           "x-axis": true,
           "y-axis": true,
@@ -723,7 +720,6 @@
           "editable": true,
           "type": "graph",
           "id": 15,
-          
           "renderer": "flot",
           "x-axis": true,
           "y-axis": true,


### PR DESCRIPTION
There was no Grafana default dashboard for OpenStack monitoring and it
was necessary to create dashboard manually when monasca-docker
integrated with OpenStack environment. This commit provides Grafana
default dashboard for OpenStack monitoring.
Conflicts:
	.env
	grafana-init/build.yml
	grafana-init/dashboards.d/08-openstack.json