### PR TITLE
Fix bug: enable alarm creation if metric name is mix case

### DIFF
--- a/monasca-api-python/build.yml
+++ b/monasca-api-python/build.yml
@@ -1,6 +1,6 @@
 repository: fest/api
 variants:
-  - tag: 2.0.4
+  - tag: 2.0.5
     aliases:
       - :pike-{date}-{time}
     args:


### PR DESCRIPTION
Story: 2001539
Task: 6349